### PR TITLE
Use exec in wrapper scripts

### DIFF
--- a/lutim/run.sh
+++ b/lutim/run.sh
@@ -8,4 +8,4 @@ sed -i -e 's/<contact>/'$CONTACT'/g' \
        -e 's/<domain>/'$DOMAIN'/g' \
        -e 's|<webroot>|'$WEBROOT'|g' /lutim/lutim.conf
 chown -R lutim:lutim /lutim /data
-cd /lutim && su lutim -c "carton exec hypnotoad -f /lutim/script/lutim"
+cd /lutim && exec su lutim -c "carton exec hypnotoad -f /lutim/script/lutim"

--- a/lychee/run.sh
+++ b/lychee/run.sh
@@ -2,4 +2,4 @@
 addgroup -g ${GID} lychee && adduser -h /lychee -s /bin/sh -D -G lychee -u ${UID} lychee
 mkdir /lychee/uploads/big /lychee/uploads/import /lychee/uploads/medium /lychee/uploads/thumb
 chown -R lychee:lychee /lychee /var/run/php-fpm.sock /var/lib/nginx /tmp
-supervisord -c /usr/local/etc/supervisord.conf
+exec supervisord -c /usr/local/etc/supervisord.conf

--- a/nextcloud/10.0/run.sh
+++ b/nextcloud/10.0/run.sh
@@ -12,4 +12,4 @@ chown -R nextcloud:nextcloud /nextcloud /data /config /apps2 /var/run/php-fpm.so
 ln -s /config/config.php /nextcloud/config/config.php
 ln -s /apps2 /nextcloud
 
-supervisord -c /etc/supervisor/supervisord.conf
+exec supervisord -c /etc/supervisor/supervisord.conf

--- a/nextcloud/9.0/run.sh
+++ b/nextcloud/9.0/run.sh
@@ -12,4 +12,4 @@ chown -R nextcloud:nextcloud /nextcloud /data /config /apps2 /var/run/php-fpm.so
 ln -s /config/config.php /nextcloud/config/config.php
 ln -s /apps2 /nextcloud
 
-supervisord -c /etc/supervisor/supervisord.conf
+exec supervisord -c /etc/supervisor/supervisord.conf

--- a/nextcloud/daily/run.sh
+++ b/nextcloud/daily/run.sh
@@ -12,4 +12,4 @@ chown -R nextcloud:nextcloud /nextcloud /data /config /apps2 /var/run/php-fpm.so
 ln -s /config/config.php /nextcloud/config/config.php
 ln -s /apps2 /nextcloud
 
-supervisord -c /etc/supervisor/supervisord.conf
+exec supervisord -c /etc/supervisor/supervisord.conf

--- a/piwik/run.sh
+++ b/piwik/run.sh
@@ -9,4 +9,4 @@ elif [ -f /config/config.ini.php ]; then
 fi
 
 chown -R piwik:piwik /piwik /config /var/run/php-fpm.sock /var/lib/nginx /tmp
-supervisord -c /usr/local/etc/supervisord.conf
+exec supervisord -c /usr/local/etc/supervisord.conf

--- a/privatebin/run.sh
+++ b/privatebin/run.sh
@@ -2,4 +2,4 @@
 addgroup -g ${GID} zerobin && adduser -h /zerobin -s /bin/sh -D -G zerobin -u ${UID} zerobin
 touch /var/run/php-fpm.sock
 chown -R zerobin:zerobin /zerobin /var/run/php-fpm.sock /var/lib/nginx /tmp
-supervisord -c /usr/local/etc/supervisord.conf
+exec supervisord -c /usr/local/etc/supervisord.conf

--- a/rainloop/run.sh
+++ b/rainloop/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 addgroup -g ${GID} rainloop && adduser -h /rainloop -s /bin/sh -D -G rainloop -u ${UID} rainloop
 chown -R rainloop:rainloop /rainloop /var/run/php-fpm.sock /var/lib/nginx /tmp
-supervisord -c /usr/local/etc/supervisord.conf
+exec supervisord -c /usr/local/etc/supervisord.conf

--- a/searx/run.sh
+++ b/searx/run.sh
@@ -4,4 +4,4 @@ sed -i -e "s|base_url : False|base_url : ${BASE_URL}|g" \
        -e "s/ultrasecretkey/$(openssl rand -hex 16)/g" \
        /usr/local/searx/searx/settings.yml
 
-python /usr/local/searx/searx/webapp.py
+exec python /usr/local/searx/searx/webapp.py

--- a/subsonic/run.sh
+++ b/subsonic/run.sh
@@ -9,7 +9,7 @@ chown -R subsonic:subsonic /data /playlists /subsonic
 
 sleep 7 # avoid 503
 
-su subsonic << EOF
+exec su subsonic << EOF
 java -Xmx200m \
   -Dsubsonic.home=/data \
   -Dsubsonic.host=0.0.0.0 \


### PR DESCRIPTION
Use exec in wrapper scripts where possible.

Rationale: Just executing something in a shell makes that shell spawn a subprocess, whereas exec makes the shell turn into that process. This gives the parent process (supervisord/tini/docker-engine) an accurate state of the actual process rather than that of a shell. Also it removes clutter from the process table.
