### PR TITLE
Add timeout on nginx conf

### DIFF
--- a/nextcloud/10.0/nginx.conf
+++ b/nextcloud/10.0/nginx.conf
@@ -95,6 +95,7 @@ http {
             fastcgi_param SCRIPT_FILENAME $document_root$1;
             fastcgi_param PATH_INFO $2;
             fastcgi_pass unix:/var/run/php-fpm.sock;
+            fastcgi_read_timeout 1200;
         }
 
         location ~* ^.+\.(jpg|jpeg|gif|bmp|ico|png|css|js|swf)$ {


### PR DESCRIPTION
I add timeout in nginx conf because when we install nextcloud or apps, the timeout stop script and make 504 error. With this fix, it work :)
(I change alose in my php.ini max_execution_time to 600)
