### PR TITLE
[Nextcloud] Updated php-fpm.conf

### DIFF
--- a/nextcloud/10.0/php-fpm.conf
+++ b/nextcloud/10.0/php-fpm.conf
@@ -9,10 +9,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
-request_terminate_timeout = 1200
+request_terminate_timeout = 0
 env[PATH] = /usr/local/bin:/usr/bin:/bin
 php_admin_value[post_max_size] = <UPLOAD_MAX_SIZE>
 php_admin_value[upload_max_filesize] = <UPLOAD_MAX_SIZE>
 php_admin_value[max_execution_time] = 10800
-php_admin_value[max_input_time] = 1200
-
+php_admin_value[max_input_time] = 3600


### PR DESCRIPTION
I updated some values of the `php-fpm.conf` to resolve issue #38.

I deactivated `request_terminate_timeout` so php won't stop after the client took too long time, which is possible when he tries to upload large files (with slow internet connection).
Increasing `max_input_time` is also a good choice (see reasons before).
