### PR TITLE
[Nextcloud] Hide PHP version banner in HTTP responses.

### DIFF
--- a/nextcloud/10.0/Dockerfile
+++ b/nextcloud/10.0/Dockerfile
@@ -86,7 +86,8 @@ RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/a
  && echo "All seems good, now unpacking ${NEXTCLOUD_TARBALL}..." \
  && tar xjf ${NEXTCLOUD_TARBALL} --strip 1 -C /nextcloud \
  && apk del ${BUILD_DEPS} php7-pear php7-dev \
- && rm -rf /var/cache/apk/* /tmp/* /root/.gnupg
+ && rm -rf /var/cache/apk/* /tmp/* /root/.gnupg \
+ && sed -i 's/expose_php =.*/expose_php = Off/' /etc/php7/php.ini
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY php-fpm.conf /etc/php7/php-fpm.conf

--- a/nextcloud/9.0/Dockerfile
+++ b/nextcloud/9.0/Dockerfile
@@ -86,7 +86,8 @@ RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/a
  && echo "All seems good, now unpacking ${NEXTCLOUD_TARBALL}..." \
  && tar xjf ${NEXTCLOUD_TARBALL} --strip 1 -C /nextcloud \
  && apk del ${BUILD_DEPS} php7-pear php7-dev \
- && rm -rf /var/cache/apk/* /tmp/* /root/.gnupg
+ && rm -rf /var/cache/apk/* /tmp/* /root/.gnupg \
+ && sed -i 's/expose_php =.*/expose_php = Off/' /etc/php7/php.ini
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY php-fpm.conf /etc/php7/php-fpm.conf

--- a/nextcloud/daily/Dockerfile
+++ b/nextcloud/daily/Dockerfile
@@ -71,7 +71,8 @@ RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/a
  && wget -q https://download.nextcloud.com/server/daily/latest.tar.bz2 \
  && tar xjf latest.tar.bz2 --strip 1 -C /nextcloud \
  && apk del ${BUILD_DEPS} php7-pear php7-dev \
- && rm -rf /var/cache/apk/* /tmp/*
+ && rm -rf /var/cache/apk/* /tmp/* \
+ && sed -i 's/expose_php =.*/expose_php = Off/' /etc/php7/php.ini
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY php-fpm.conf /etc/php7/php-fpm.conf


### PR DESCRIPTION
The currently used php.ini (`/etc/php7/php.ini`) on the nextcloud docker container uses the setting:

> `expose_php = On`

While this is the default setting, it allows [web server fingerprinting](https://www.owasp.org/index.php/Fingerprint_Web_Server_%28OTG-INFO-002%29) and is not considered a security best-practice.

Therefore, I propose to set it to `Off`.
