### PR TITLE
Added autoconfiguration to nextcloud image

### DIFF
--- a/nextcloud/10.0/Dockerfile
+++ b/nextcloud/10.0/Dockerfile
@@ -93,6 +93,7 @@ COPY php-fpm.conf /etc/php7/php-fpm.conf
 COPY opcache.ini /etc/php7/conf.d/00_opcache.ini
 COPY apcu.ini /etc/php7/conf.d/apcu.ini
 COPY run.sh /usr/local/bin/run.sh
+COPY setup.sh /usr/local/bin/setup.sh
 COPY occ /usr/local/bin/occ
 COPY s6.d /etc/s6.d
 

--- a/nextcloud/10.0/run.sh
+++ b/nextcloud/10.0/run.sh
@@ -1,17 +1,30 @@
 #!/bin/sh
 
-if [ ! -f /config/config.php ]; then
-    echo -e "<?php\n\$CONFIG = array (\n  'datadirectory' => '/data',\n);" > /config/config.php
-fi
-
 sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf /etc/php7/php-fpm.conf \
        -e "s/<APC_SHM_SIZE>/$APC_SHM_SIZE/g" /etc/php7/conf.d/apcu.ini \
        -e "s/<OPCACHE_MEM_SIZE>/$OPCACHE_MEM_SIZE/g" /etc/php7/conf.d/00_opcache.ini \
        -e "s/<CRON_PERIOD>/$CRON_PERIOD/g" /etc/s6.d/cron/run
 
+# Put the configuration and apps into volumes
+ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
+ln -sf /apps2 /nextcloud &>/dev/null
+
 chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /tmp /etc/s6.d
 
-ln -s /config/config.php /nextcloud/config/config.php &>/dev/null
-ln -s /apps2 /nextcloud &>/dev/null
+if [ ! -f /config/config.php ]; then
+    # New installation, run the setup
+    /usr/local/bin/setup.sh
+else
+    occ upgrade
+    if [ \( $? -ne 0 \) -a \( $? -ne 3 \) ]; then
+        echo "Trying ownCloud upgrade again to work around ownCloud upgrade bug..."
+        occ upgrade
+        if [ \( $? -ne 0 \) -a \( $? -ne 3 \) ]; then exit 1; fi
+        occ maintenance:mode --off
+        echo "...which seemed to work."
+    fi
+fi
+
+chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /tmp /etc/s6.d
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/10.0/setup.sh
+++ b/nextcloud/10.0/setup.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Nextcloud
+##########################
+
+#source setup/functions.sh # load our functions
+#source /etc/mailinabox.conf # load global vars
+CONFIGFILE=/config/config.php
+
+
+# Create an initial configuration file.
+instanceid=oc$(echo $PRIMARY_HOSTNAME | sha1sum | fold -w 10 | head -n 1)
+cat > $CONFIGFILE <<EOF;
+<?php
+\$CONFIG = array (
+  'datadirectory' => '/data',
+
+  'instanceid' => '$instanceid',
+);
+?>
+EOF
+
+# Create an auto-configuration file to fill in database settings
+# when the install script is run. Make an administrator account
+# here or else the install can't finish.
+adminpassword=$(dd if=/dev/urandom bs=1 count=40 2>/dev/null | sha1sum | fold -w 30 | head -n 1)
+cat > /nextcloud/config/autoconfig.php <<EOF;
+<?php
+\$AUTOCONFIG = array (
+  # storage/database
+  'directory'     => '/data',
+  'dbtype'        => '${DB_TYPE:-sqlite3}',
+  'dbname'        => '${DB_NAME:-nextcloud}',
+  'dbuser'        => '${DB_USER:-nextcloud}',
+  'dbpass'        => '${DB_PASSWORD:-password}',
+  'dbhost'        => '${DB_HOST:-nextcloud-db}',
+  'dbtableprefix' => 'oc_',
+EOF
+if [[ ! -z "$ADMIN_USER"  ]]; then
+  cat >> /nextcloud/config/autoconfig.php <<EOF;
+  # create an administrator account with a random password so that
+  # the user does not have to enter anything on first load of ownCloud
+  'adminlogin'    => '${ADMIN_USER}',
+  'adminpass'     => '${ADMIN_PASSWORD}',
+EOF
+fi
+cat >> /nextcloud/config/autoconfig.php <<EOF;
+);
+?>
+EOF
+
+echo "Starting automatic configuration..."
+# Execute ownCloud's setup step, which creates the ownCloud database.
+# It also wipes it if it exists. And it updates config.php with database
+# settings and deletes the autoconfig.php file.
+(cd /nextcloud; php7 index.php)
+echo "Automatic configuration finished."
+
+# Update config.php.
+# * trusted_domains is reset to localhost by autoconfig starting with ownCloud 8.1.1,
+#   so set it here. It also can change if the box's PRIMARY_HOSTNAME changes, so
+#   this will make sure it has the right value.
+# * Some settings weren't included in previous versions of Mail-in-a-Box.
+# * We need to set the timezone to the system timezone to allow fail2ban to ban
+#   users within the proper timeframe
+# * We need to set the logdateformat to something that will work correctly with fail2ban
+# Use PHP to read the settings file, modify it, and write out the new settings array.
+echo ${TZ:-UTC} >/etc/timezone
+
+TIMEZONE=$(cat /etc/timezone)
+CONFIG_TEMP=$(/bin/mktemp)
+php7 <<EOF > $CONFIG_TEMP && mv $CONFIG_TEMP $CONFIGFILE
+<?php
+include("/config/config.php");
+
+\$CONFIG['trusted_domains'] = array('$VIRTUAL_HOST');
+
+//\$CONFIG['memcache.local'] = '\\OC\\Memcache\\Memcached';
+//\$CONFIG['overwrite.cli.url'] = '/cloud';
+\$CONFIG['mail_from_address'] = 'administrator'; # just the local part, matches our master administrator address
+
+\$CONFIG['logtimezone'] = '$TIMEZONE';
+\$CONFIG['logdateformat'] = 'Y-m-d H:i:s';
+
+echo "<?php\n\\\$CONFIG = ";
+var_export(\$CONFIG);
+echo ";";
+?>
+EOF
+
+chown -R $UID:$GID /config
+# Enable/disable apps. Note that this must be done after the ownCloud setup.
+# The firstrunwizard gave Josh all sorts of problems, so disabling that.
+# user_external is what allows ownCloud to use IMAP for login. The contacts
+# and calendar apps are the extensions we really care about here.
+occ app:disable firstrunwizard


### PR DESCRIPTION
Adding a database as backend to nextcloud and having to provide the database credentials by hand is not necessary if you use the autoconfiguration feature of nextcloud. Therefore I added this to this wonderful docker image.
