### PR TITLE
Updated version of Piwik to 2.17.0 (latest).

### DIFF
--- a/piwik/Dockerfile
+++ b/piwik/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.4
 MAINTAINER Wonderfall <wonderfall@mondedie.fr>
 
-ARG VERSION=2.16.5
+ARG VERSION=2.17.0
 
 ARG GPG_matthieu="814E 346F A01A 20DB B04B  6807 B5DB D592 5590 A237"
 


### PR DESCRIPTION
According to the latest update of Piwik [2.17.0](https://piwik.org/changelog/piwik-2-17-0/) I've updated the docker file to build a new container with the newest Piwik version.