### PR TITLE
Make nextcloud chown idempotent

### DIFF
--- a/nextcloud/10.0-armhf/run.sh
+++ b/nextcloud/10.0-armhf/run.sh
@@ -30,10 +30,4 @@ else
     fi
 fi
 
-for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
-  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
-    chown -R $UID:$GID $dir
-  fi
-done
-
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/10.0-armhf/run.sh
+++ b/nextcloud/10.0-armhf/run.sh
@@ -10,7 +10,11 @@ sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf /etc/ph
 ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
 ln -sf /apps2 /nextcloud &>/dev/null
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 if [ ! -f /config/config.php ]; then
     # New installation, run the setup
@@ -26,6 +30,10 @@ else
     fi
 fi
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/10.0/run.sh
+++ b/nextcloud/10.0/run.sh
@@ -30,10 +30,4 @@ else
     fi
 fi
 
-for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
-  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
-    chown -R $UID:$GID $dir
-  fi
-done
-
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/10.0/run.sh
+++ b/nextcloud/10.0/run.sh
@@ -10,7 +10,11 @@ sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf /etc/ph
 ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
 ln -sf /apps2 /nextcloud &>/dev/null
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 if [ ! -f /config/config.php ]; then
     # New installation, run the setup
@@ -26,6 +30,10 @@ else
     fi
 fi
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/daily-armhf/run.sh
+++ b/nextcloud/daily-armhf/run.sh
@@ -30,10 +30,4 @@ else
     fi
 fi
 
-for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
-  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
-    chown -R $UID:$GID $dir
-  fi
-done
-
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/daily-armhf/run.sh
+++ b/nextcloud/daily-armhf/run.sh
@@ -10,7 +10,11 @@ sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf /etc/ph
 ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
 ln -sf /apps2 /nextcloud &>/dev/null
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 if [ ! -f /config/config.php ]; then
     # New installation, run the setup
@@ -26,6 +30,10 @@ else
     fi
 fi
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/daily/run.sh
+++ b/nextcloud/daily/run.sh
@@ -30,10 +30,4 @@ else
     fi
 fi
 
-for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
-  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
-    chown -R $UID:$GID $dir
-  fi
-done
-
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/nextcloud/daily/run.sh
+++ b/nextcloud/daily/run.sh
@@ -10,7 +10,11 @@ sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf /etc/ph
 ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
 ln -sf /apps2 /nextcloud &>/dev/null
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 if [ ! -f /config/config.php ]; then
     # New installation, run the setup
@@ -26,6 +30,10 @@ else
     fi
 fi
 
-chown -R $UID:$GID /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /tmp /etc/s6.d
+for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+  if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    chown -R $UID:$GID $dir
+  fi
+done
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d


### PR DESCRIPTION
Currently, the nextloud chown always gets execute twice on startup, which may take quite a lot of time on larger collections.

This PR makes the run script check if there are any files not owned by $UID:$GID and only run the chown if that is the case.