### PR TITLE
Volume /config_default on NFS, so that /config can stay inside container.

### DIFF
--- a/nextcloud/10.0/Dockerfile
+++ b/nextcloud/10.0/Dockerfile
@@ -108,7 +108,7 @@ COPY s6.d /etc/s6.d
 
 RUN chmod +x /usr/local/bin/* /etc/s6.d/*/* /etc/s6.d/.s6-svscan/*
 
-VOLUME /data /config /apps2 /var/lib/redis
+VOLUME /data /config /config_default /apps2 /var/lib/redis
 
 EXPOSE 8888
 


### PR DESCRIPTION
Added /config_default volume. If file /config_default/config.php exists, it is copied to /config.

If /config is on NFS, flock() does not work in github.com/nextcloud/server/blob/master/lib/private/Config.php .
On kubernetes, or other similar deployments, mount /data, /apps2 and /config_default . Every time pod/container is created, it will use default config on NFS.

Tested with image https://hub.docker.com/r/jayprakashji/nextcloud/ 