### PR TITLE
[boring-nginx] increase download file size to 10GB

### DIFF
--- a/boring-nginx/proxy_params
+++ b/boring-nginx/proxy_params
@@ -4,3 +4,4 @@ proxy_set_header        X-Forwarded-For      $proxy_add_x_forwarded_for;
 proxy_set_header        X-Remote-Port        $remote_port;
 proxy_set_header        X-Forwarded-Proto    $scheme;
 proxy_redirect          off;
+proxy_max_temp_file_size 10737m;


### PR DESCRIPTION
If you use "broing-nginx" as proxy for example your nextcloud docker, then you're not be able to download bigger files than 1GB. 
I add `proxy_max_temp_file_size 10737m;` to the file [proxy_params](https://github.com/Wonderfall/dockerfiles/blob/master/boring-nginx/proxy_params) to fix this. 

Maybe you want to add it to other dockerfiles too ([nginx](https://github.com/Wonderfall/dockerfiles/tree/master/nginx)).