### PR TITLE
Be noisy about updating permissions

### DIFF
--- a/nextcloud/11.0/run.sh
+++ b/nextcloud/11.0/run.sh
@@ -10,11 +10,16 @@ sed -i -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /etc/nginx/nginx.conf /etc/ph
 ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
 ln -sf /apps2 /nextcloud &>/dev/null
 
+echo "Updating permissions..."
 for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
   if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
+    echo "Updating permissions in $dir..."
     chown -R $UID:$GID $dir
+  else
+    echo "Permissions in $dir are correct."
   fi
 done
+echo "Done updating permissions."
 
 if [ ! -f /config/config.php ]; then
     # New installation, run the setup


### PR DESCRIPTION
In #75, I mentioned that I was a little stumped why my Nextcloud container was showing a `502 Bad Gateway` error. In the end, it turned out that it was just updating the permissions in the container, which are set to `nobody:nogroup`, but need to be chowned to `991:991` when first starting a fresh container. This PR seeks to make that a little more obvious to the user, in case they choose to use `docker-compose logs -f nextcloud` or such.