### PR TITLE
Fix "Cannot write into apps directory"

### DIFF
--- a/nextcloud/11.0-armhf/run.sh
+++ b/nextcloud/11.0-armhf/run.sh
@@ -11,7 +11,7 @@ ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
 ln -sf /apps2 /nextcloud &>/dev/null
 
 echo "Updating permissions..."
-for dir in /nextcloud/config /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+for dir in /nextcloud/config /nextcloud/apps /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
   if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
     echo "Updating permissions in $dir..."
     chown -R $UID:$GID $dir

--- a/nextcloud/11.0/run.sh
+++ b/nextcloud/11.0/run.sh
@@ -11,7 +11,7 @@ ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null
 ln -sf /apps2 /nextcloud &>/dev/null
 
 echo "Updating permissions..."
-for dir in /nextcloud/config /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
+for dir in /nextcloud/config /nextcloud/apps /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
   if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then
     echo "Updating permissions in $dir..."
     chown -R $UID:$GID $dir


### PR DESCRIPTION
After upgrading to latest docker image, I got the following error message:

```
nextcloud_1  | Updating permissions...
nextcloud_1  | Updating permissions in /nextcloud/config...
nextcloud_1  | Permissions in /data are correct.
nextcloud_1  | Permissions in /config are correct.
nextcloud_1  | Permissions in /apps2 are correct.
nextcloud_1  | Permissions in /etc/nginx are correct.
nextcloud_1  | Permissions in /etc/php7 are correct.
nextcloud_1  | Permissions in /var/log are correct.
nextcloud_1  | Permissions in /var/lib/nginx are correct.
nextcloud_1  | Permissions in /var/lib/redis are correct.
nextcloud_1  | Permissions in /tmp are correct.
nextcloud_1  | Permissions in /etc/s6.d are correct.
nextcloud_1  | Done updating permissions.
nextcloud_1  | Cannot write into "apps" directory
nextcloud_1  | This can usually be fixed by <a href="https://docs.nextcloud.com/server/11/go.php?to=admin-dir_permissions" target="_blank" rel="noreferrer">giving the webserver write access to the apps directory</a> or disabling the appstore in the config file.
nextcloud_1  | 
nextcloud_1  | An unhandled exception has been thrown:
nextcloud_1  | Exception: Environment not properly prepared. in /nextcloud/lib/private/Console/Application.php:144
nextcloud_1  | Stack trace:
nextcloud_1  | #0 /nextcloud/console.php(89): OC\Console\Application->loadCommands(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
nextcloud_1  | #1 /nextcloud/occ(11): require_once('/nextcloud/cons...')
nextcloud_1  | #2 {main}Trying ownCloud upgrade again to work around ownCloud upgrade bug...
nextcloud_1  | Cannot write into "apps" directory
nextcloud_1  | This can usually be fixed by <a href="https://docs.nextcloud.com/server/11/go.php?to=admin-dir_permissions" target="_blank" rel="noreferrer">giving the webserver write access to the apps directory</a> or disabling the appstore in the config file.
nextcloud_1  | 
nextcloud_1  | An unhandled exception has been thrown:
nextcloud_1  | Exception: Environment not properly prepared. in /nextcloud/lib/private/Console/Application.php:144
nextcloud_1  | Stack trace:
nextcloud_1  | #0 /nextcloud/console.php(89): OC\Console\Application->loadCommands(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
nextcloud_1  | #1 /nextcloud/occ(11): require_once('/nextcloud/cons...')
nextcloud_1  | #2 {main}
```

After some digging, I found out this was caused by commit https://github.com/Wonderfall/dockerfiles/commit/33a9a79065261895ab00f7e7e6b9a8c620c1ad10.

This PR adds back /apps to the list of directories to chown.