### PR TITLE
Patch to create nextcloud user

### DIFF
--- a/nextcloud/11.0/run.sh
+++ b/nextcloud/11.0/run.sh
@@ -15,9 +15,12 @@ mv nextcloud fix && mv fix nextcloud # fix strange bug
 # Purge and then recreate the nextcloud user, using the UID and GID passed in via the environment.
 # This makes running the occ command for maintenance easier.
 
-echo "Adding 'nextcloud' account."
-userdel nextcloud
-useradd -u $UID -g -GID -d /nextcloud -r -s /bin/false nextcloud
+echo "Purging existing 'nextcloud' account and group."
+delgroup nextcloud
+deluser nextcloud
+echo "Adding 'nextcloud' account and group."
+addgroup -S -g $GID nextcloud
+adduser -h /nextcloud -s /bin/false -S -u $UID nextcloud
 
 echo "Updating permissions..."
 for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do

--- a/nextcloud/11.0/run.sh
+++ b/nextcloud/11.0/run.sh
@@ -12,6 +12,13 @@ ln -sf /apps2 /nextcloud &>/dev/null
 
 mv nextcloud fix && mv fix nextcloud # fix strange bug
 
+# Purge and then recreate the nextcloud user, using the UID and GID passed in via the environment.
+# This makes running the occ command for maintenance easier.
+
+echo "Adding 'nextcloud' account."
+userdel nextcloud
+useradd -u $UID -g -GID -d /nextcloud -r -s /bin/false nextcloud
+
 echo "Updating permissions..."
 for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/lib/nginx /var/lib/redis /tmp /etc/s6.d; do
   if $(find $dir ! -user $UID -o ! -group $GID|egrep '.' -q); then


### PR DESCRIPTION
Currently, the UID and GID from the environment are used to ensure that the file permissions and process ownership are correctly set. However, when one is working in a shell within the container, it becomes more difficult to execute tools such as 'occ', which want to be run as the nextcloud user.

This removes any user/group named nextcloud, and then create a new nextcloud user and nextcloud group using the UID and GID specified in the environment.