### PR TITLE
boring-nginx: alpine 3.5

### DIFF
--- a/boring-nginx/Dockerfile
+++ b/boring-nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.5
 
 ENV UID=991 GID=991
 
@@ -29,8 +29,7 @@ ARG NGINX_3RD_PARTY_MODULES=" \
     --add-module=/tmp/headers-more-nginx-module \
     --add-module=/tmp/ngx_brotli"
 
-RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
- && NB_CORES=${BUILD_CORES-$(getconf _NPROCESSORS_CONF)} \
+RUN NB_CORES=${BUILD_CORES-$(getconf _NPROCESSORS_CONF)} \
  && BUILD_DEPS=" \
     build-base \
     linux-headers \
@@ -90,8 +89,8 @@ RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/a
  && ./configure \
     --prefix=/etc/nginx \
     --sbin-path=/usr/sbin/nginx \
-    --with-cc-opt="-O3 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wno-deprecated-declarations -I ../boringssl/.openssl/include/" \
-    --with-ld-opt="-Wl,-Bsymbolic-functions -Wl,-z,relro -L ../boringssl/.openssl/lib" \
+    --with-cc-opt="-O3 -fPIE -Wformat -Werror=format-security -Wno-deprecated-declarations -I ../boringssl/.openssl/include/" \
+    --with-ld-opt="-L ../boringssl/.openssl/lib" \
     --http-log-path=/var/log/nginx/access.log \
     --error-log-path=/var/log/nginx/error.log \
     ${NGINX_MODULES} \

--- a/unmaintained/nginx/Dockerfile
+++ b/unmaintained/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 MAINTAINER Wonderfall <wonderfall@schrodinger.io>
 
 ENV UID=991 GID=991
@@ -9,8 +9,7 @@ ARG GPG_LIBRESSL="A1EB 079B 8D3E B92B 4EBD  3139 663A F51B D5E4 D8D5"
 ARG GPG_NGINX="B0F4 2533 73F8 F6F5 10D4  2178 520A 9993 A1C0 52F8"
 ARG BUILD_CORES
 
-RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
- && NB_CORES=${BUILD_CORES-$(getconf _NPROCESSORS_CONF)} \
+RUN NB_CORES=${BUILD_CORES-$(getconf _NPROCESSORS_CONF)} \
  && BUILD_DEPS=" \
     build-base \
     linux-headers \
@@ -71,8 +70,7 @@ RUN echo "@commuedge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/a
  && ./configure \
     --prefix=/etc/nginx \
     --sbin-path=/usr/sbin/nginx \
-    --with-cc-opt='-O3 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wno-deprecated-declarations' \
-    --with-ld-opt='-Wl,-Bsymbolic-functions -Wl,-z,relro' \
+    --with-cc-opt='-O3 -fPIE -Wformat -Werror=format-security -Wno-deprecated-declarations' \
     --with-openssl=/tmp/libressl-${LIBRESSL_VERSION} \
     --with-http_ssl_module \
     --with-http_v2_module \


### PR DESCRIPTION
* https://alpinelinux.org/posts/Alpine-3.5.0-released.html
* https://github.com/alpinelinux/aports/tree/v3.5.2/main/gcc
  - 001_all_default-ssp-strong.patch
  - 002_all_default-relro.patch
  - 003_all_default-fortify-source.patch
  - 207-static-pie.patch — main/gcc: add ld -Bsymbolic for static pie linking
  - main/gcc: upgrade to 6.1.0
    - use --enable-default-pie
    - patch bind now, ssp-strong, fortify and as-needed to be defaults
    - remove upstreamed musl patches, add current musl patches
    - support musl's static pie
* https://github.com/alpinelinux/aports/tree/v3.5.2/community/tini


