### PR TITLE
[boring-nginx] Allow global read/write to stdout/stderr for logs

### DIFF
--- a/boring-nginx/run.sh
+++ b/boring-nginx/run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 chown -R $UID:$GID /etc/nginx /var/log/nginx /sites-enabled /conf.d /certs /www /tmp
 chmod -R 700 /certs
+chmod 666 /dev/std*
 exec su-exec $UID:$GID /sbin/tini -- nginx


### PR DESCRIPTION
I use /dev/stdout and /dev/stderr for my `access_log` & `error_log` respectively to allow nginx logs in `docker logs` and this small change would remove the need for a separate entrypoint script