### PR TITLE
check for installed Nextcloud to allow container restart before install

### DIFF
--- a/nextcloud/daily/run.sh
+++ b/nextcloud/daily/run.sh
@@ -32,14 +32,16 @@ if [ ! -f /config/config.php ]; then
     # New installation, run the setup
     /usr/local/bin/setup.sh
 else
+  if [ $(occ | head -n 1 | grep -ic "Nextcloud version.*") == "1" ] ; then  
     occ upgrade
     if [ \( $? -ne 0 \) -a \( $? -ne 3 \) ]; then
-        echo "Trying ownCloud upgrade again to work around ownCloud upgrade bug..."
+        echo "Trying Nextcloud upgrade again to work around Nextcloud upgrade bug..."
         occ upgrade
         if [ \( $? -ne 0 \) -a \( $? -ne 3 \) ]; then exit 1; fi
         occ maintenance:mode --off
         echo "...which seemed to work."
     fi
+  fi
 fi
 
 exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d


### PR DESCRIPTION
The current version did not allow a restart of the Nextcloud container right after it had been created and the configuration had not been completed after the first start. Should be fixed now.