### PR TITLE
[nextcloud] temporarily pull current libressl from different mirror (fix #172)

### DIFF
--- a/nextcloud/daily/Dockerfile
+++ b/nextcloud/daily/Dockerfile
@@ -15,6 +15,7 @@ ENV UID=991 GID=991 \
     DOMAIN=localhost
 
 RUN echo "@testing https://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
  && BUILD_DEPS=" \
     gnupg \
     tar \
@@ -28,7 +29,7 @@ RUN echo "@testing https://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/r
     ${BUILD_DEPS} \
     nginx \
     s6 \
-    libressl \
+    libressl@edge \
     ca-certificates \
     libsmbclient \
     samba-client \


### PR DESCRIPTION
This should fix current issue #172 and let builds run again