### PR TITLE
[nextcloud] remove error_pages redirection from nginx.conf

### DIFF
--- a/nextcloud/11.0/nginx.conf
+++ b/nextcloud/11.0/nginx.conf
@@ -37,9 +37,6 @@ http {
         client_max_body_size <UPLOAD_MAX_SIZE>;
         fastcgi_buffers 64 4K;
 
-        error_page 403 /core/templates/403.php;
-        error_page 404 /core/templates/404.php;
-        
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
         add_header X-Frame-Options "SAMEORIGIN";
         add_header X-Content-Type-Options nosniff;

--- a/nextcloud/daily/nginx.conf
+++ b/nextcloud/daily/nginx.conf
@@ -37,9 +37,6 @@ http {
         client_max_body_size <UPLOAD_MAX_SIZE>;
         fastcgi_buffers 64 4K;
 
-        error_page 403 /core/templates/403.php;
-        error_page 404 /core/templates/404.php;
-        
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
         add_header X-Frame-Options "SAMEORIGIN";
         add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
Like @InfernoZeus mentioned, the nginx conf was updated by Nextcloud
Fix #137