### PR TITLE
Only update permissions for /ghost/content & /etc/s6.d

### DIFF
--- a/ghost/rootfs/usr/local/bin/run.sh
+++ b/ghost/rootfs/usr/local/bin/run.sh
@@ -37,7 +37,7 @@ if [ "$ENABLE_ISSO" == "True" ] && ! grep -q 'isso' /ghost/content/themes/casper
 fi
 
 echo "> Updating permissions..."
-chown -R ${UID}:${GID} /ghost /etc/s6.d
+chown -R ${UID}:${GID} /ghost/content /etc/s6.d
 
 echo "> Executing process..."
 if [ '$@' == '' ]; then


### PR DESCRIPTION
Why wanted to update /ghost, including the `node_modules` folder?
This is taking a lots of time while only updating `/ghost/content` and `/etc/s6.d` allow to start ghost faster.