### PR TITLE
Fix quoting in nextcloud cli commands

### DIFF
--- a/nextcloud/rootfs/usr/local/bin/occ
+++ b/nextcloud/rootfs/usr/local/bin/occ
@@ -1,2 +1,2 @@
 #!/bin/sh
-su-exec $UID:$GID php -d memory_limit=<MEMORY_LIMIT> -f /nextcloud/occ $@
+su-exec $UID:$GID php -d memory_limit=<MEMORY_LIMIT> -f /nextcloud/occ "$@"


### PR DESCRIPTION
`occ config:app:set --value="Name with spaces" theming name` produces error:

```
[Symfony\Component\Console\Exception\RuntimeException]
Too many arguments.
```

this patch fixed it